### PR TITLE
Resolve issue with parsing of null bytes (0x00 and 0xFF) before, between, or after a valid tag

### DIFF
--- a/BerTlv/BerTlv.csproj
+++ b/BerTlv/BerTlv.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
     <PackageId>BerTlv.NET</PackageId>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <Authors>Kyle Spearrin</Authors>
     <Company />
     <Product />

--- a/BerTlv/Tlv.cs
+++ b/BerTlv/Tlv.cs
@@ -104,31 +104,45 @@ namespace BerTlv
         {
             for(int i = 0, start = 0; i < rawTlv.Length; start = i)
             {
-                // parse Tag
-                bool constructedTlv = (rawTlv[i] & 0x20) != 0;
-                bool moreBytes = (rawTlv[i] & 0x1F) == 0x1F;
-                while(moreBytes && (rawTlv[++i] & 0x80) != 0) ;
-                i++;
+                // 0x00 and 0xFF can be used as padding before, between, and after tags
+                if (rawTlv[i] == 0x00 || rawTlv[i] == 0xFF)
+                {
+                    i++;
+                    continue;
+                }
 
+                // bit6 being 1 indicates that the tag is 'constructed' (contains more tags within it)
+                bool constructedTlv = (rawTlv[i] & 0x20) != 0;
+
+                // bit1 through 5 being 1 indicates that the tag is more than one byte long
+                // recognize this and keep looking until we find the last byte of the tag, indicated by bit8 being 0
+                bool multiByteTag = (rawTlv[i] & 0x1F) == 0x1F;
+                while(multiByteTag && (rawTlv[++i] & 0x80) != 0) ;
+
+                // i is on the last byte of the tag, so move it forward one and 
+                // retreve the tag value from the raw tlv
+                i++;
                 int tag = GetInt(rawTlv, start, i - start);
 
-                // parse Length
+                // bit8 being 1 indicates that the length is multiple bytes long
                 bool multiByteLength = (rawTlv[i] & 0x80) != 0;
 
                 int length = multiByteLength ? GetInt(rawTlv, i + 1, rawTlv[i] & 0x1F) : rawTlv[i];
                 i = multiByteLength ? i + (rawTlv[i] & 0x1F) + 1 : i + 1;
 
+                // i is on the last byte of the length, so move it forward by the length we found
                 i += length;
 
+                // now that we know the start position and length of the data, retrieve it
+                // then create the Tlv object and add it to the list
                 byte[] rawData = new byte[i - start];
                 Array.Copy(rawTlv, start, rawData, 0, i - start);
                 var tlv = new Tlv(tag, length, rawData.Length - length, rawData);
                 result.Add(tlv);
 
+                // if this was a constructed tag, parse its value into individual Tlv children as well
                 if(constructedTlv)
-                {
                     ParseTlv(tlv.Value, tlv.Children);
-                }
             }
         }
 

--- a/BerTlv/Tlv.cs
+++ b/BerTlv/Tlv.cs
@@ -26,26 +26,32 @@ namespace BerTlv
         /// The raw TLV data.
         /// </summary>
         public byte[] Data { get; private set; }
+
         /// <summary>
         /// The raw TLV data.
         /// </summary>
         public string HexData { get { return GetHexString(Data); } }
+
         /// <summary>
         /// The TLV tag.
         /// </summary>
         public int Tag { get; private set; }
+
         /// <summary>
         /// The TLV tag.
         /// </summary>
         public string HexTag { get { return Tag.ToString("X"); } }
+
         /// <summary>
         /// The length of the TLV value.
         /// </summary>
         public int Length { get; private set; }
+
         /// <summary>
         /// The length of the TLV value.
         /// </summary>
         public string HexLength { get { return Length.ToString("X"); } }
+
         /// <summary>
         /// The TLV value.
         /// </summary>
@@ -58,14 +64,36 @@ namespace BerTlv
                 return result;
             }
         }
+
         /// <summary>
         /// The TLV value.
         /// </summary>
         public string HexValue { get { return GetHexString(Value); } }
+
         /// <summary>
         /// TLV children.
         /// </summary>
         public ICollection<Tlv> Children { get; set; }
+
+        /// <summary>
+        /// Parse TLV data.
+        /// </summary>
+        /// <param name="tlv">The hex TLV blob.</param>
+        /// <returns>A collection of TLVs.</returns>
+        public static ICollection<Tlv> Parse(string tlv)
+        {
+            return ParseTlv(tlv);
+        }
+
+        /// <summary>
+        /// Parse TLV data.
+        /// </summary>
+        /// <param name="tlv">The byte array TLV blob.</param>
+        /// <returns>A collection of TLVs.</returns>
+        public static ICollection<Tlv> Parse(byte[] rawTlv)
+        {
+            return ParseTlv(rawTlv);
+        }
 
         /// <summary>
         /// Parse TLV data.
@@ -105,7 +133,7 @@ namespace BerTlv
             for(int i = 0, start = 0; i < rawTlv.Length; start = i)
             {
                 // 0x00 and 0xFF can be used as padding before, between, and after tags
-                if (rawTlv[i] == 0x00 || rawTlv[i] == 0xFF)
+                if (rawTlv[i] == 0x00)
                 {
                     i++;
                     continue;
@@ -141,8 +169,10 @@ namespace BerTlv
                 result.Add(tlv);
 
                 // if this was a constructed tag, parse its value into individual Tlv children as well
-                if(constructedTlv)
+                if (constructedTlv)
+                {
                     ParseTlv(tlv.Value, tlv.Children);
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ICollection<Tlv> tlvs = Tlv.ParseTlv("6F1A840E315041592E5359532E4444463031A50888
 
 ### 2.0.3
 
-Fixes issue with parsing of null bytes (0x00 and 0xFF) before, between, or after a valid tag
+Fixes issue with parsing of null bytes (0x00) before, between, or after a valid tag
 
 ### 2.0.2
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ ICollection<Tlv> tlvs = Tlv.ParseTlv("6F1A840E315041592E5359532E4444463031A50888
 
 ## Changelog
 
+### 2.0.3
+
+Fixes issue with parsing of null bytes (0x00 and 0xFF) before, between, or after a valid tag
+
 ### 2.0.2
 
 Add `netstandard2.0` support.

--- a/Test/TlvTest.cs
+++ b/Test/TlvTest.cs
@@ -9,28 +9,56 @@ namespace Test
     public class TlvTest
     {
         // Verify: http://www.emvlab.org/tlvutils/?data=6F1A840E315041592E5359532E4444463031A5088801025F2D02656E
-        private string _emvHexTlv = "6F1A840E315041592E5359532E4444463031A5088801025F2D02656E";
+        private string _validAsciiHexString = "6F1A840E315041592E5359532E4444463031A5088801025F2D02656E";
+
+        // Note: emvlab does not correctly parse inline and trailing padding (0x00, 0xFF), but the specification 
+        // allows for it. The TLV string below should be parsed in the same way as the one above
+        private string _validAsciiHexStringWithPadding = "006F1B840E315041592E5359532E444446303100A5088801025F2D02656EFFFF";
 
         [Fact]
         [Trait("Build", "Run")]
-        public void ParseEmvHexTest()
+        public void ShouldParseValidAsciiHexString()
         {
-            var tlvs = Tlv.ParseTlv(_emvHexTlv);
+            var tlvs = Tlv.ParseTlv(_validAsciiHexString);
 
             AssertTlv(tlvs);
         }
 
         [Fact]
         [Trait("Build", "Run")]
-        public void ParseEmvByteTest()
+        public void ShouldParseValidHexArray()
         {
-            var emvBytes = Enumerable
-                .Range(0, _emvHexTlv.Length)
+            var validHexArray = Enumerable
+                .Range(0, _validAsciiHexString.Length)
                 .Where(x => x % 2 == 0)
-                .Select(x => Convert.ToByte(_emvHexTlv.Substring(x, 2), 16))
+                .Select(x => Convert.ToByte(_validAsciiHexString.Substring(x, 2), 16))
                 .ToArray();
 
-            var tlvs = Tlv.ParseTlv(emvBytes);
+            var tlvs = Tlv.ParseTlv(validHexArray);
+
+            AssertTlv(tlvs);
+        }
+
+        [Fact]
+        [Trait("Build", "Run")]
+        public void ShouldParseValidAsciiHexStringWithPadding()
+        {
+            var tlvs = Tlv.ParseTlv(_validAsciiHexStringWithPadding);
+
+            AssertTlv(tlvs);
+        }
+
+        [Fact]
+        [Trait("Build", "Run")]
+        public void ShouldParseValidHexArrayStringWithPadding()
+        {
+            var validHexArrayWithPadding = Enumerable
+                .Range(0, _validAsciiHexStringWithPadding.Length)
+                .Where(x => x % 2 == 0)
+                .Select(x => Convert.ToByte(_validAsciiHexStringWithPadding.Substring(x, 2), 16))
+                .ToArray();
+
+            var tlvs = Tlv.ParseTlv(validHexArrayWithPadding);
 
             AssertTlv(tlvs);
         }

--- a/Test/TlvTest.cs
+++ b/Test/TlvTest.cs
@@ -13,7 +13,21 @@ namespace Test
 
         // Note: emvlab does not correctly parse inline and trailing padding (0x00, 0xFF), but the specification 
         // allows for it. The TLV string below should be parsed in the same way as the one above
-        private string _validAsciiHexStringWithPadding = "006F1B840E315041592E5359532E444446303100A5088801025F2D02656EFFFF";
+        private string _validAsciiHexStringWithPadding = "006F1B840E315041592E5359532E444446303100A5088801025F2D02656E0000";
+
+        [Fact]
+        [Trait("Build", "Run")]
+        public void ShouldThrowExceptionOnEmptyString()
+        {
+            Assert.Throws<ArgumentException>(() => { var tlvs = Tlv.ParseTlv(""); });
+        }
+
+        [Fact]
+        [Trait("Build", "Run")]
+        public void ShouldThrowExceptionOnEmptyHexArray()
+        {
+            Assert.Throws<ArgumentException>(() => { var tlvs = Tlv.ParseTlv(new byte[] { }); });
+        }
 
         [Fact]
         [Trait("Build", "Run")]
@@ -50,7 +64,7 @@ namespace Test
 
         [Fact]
         [Trait("Build", "Run")]
-        public void ShouldParseValidHexArrayStringWithPadding()
+        public void ShouldParseValidHexArrayWithPadding()
         {
             var validHexArrayWithPadding = Enumerable
                 .Range(0, _validAsciiHexStringWithPadding.Length)
@@ -89,5 +103,6 @@ namespace Test
             Assert.NotNull(_6FA55F2D);
             Assert.True(_6FA55F2D.HexValue == "656E");
         }
+
     }
 }


### PR DESCRIPTION
EMV allows for null bytes (0x00 and 0xFF) to exist before, between, and after valid tags - both in constructed tags and outside of them.

This PR adds tests that exhibit an issue with parsing of TLV data that contains padding bytes, and resolves that issue by skipping those 'null' bytes when scanning for a tag. It also adds some comments to clarify the 'magic numbers' used in bitwise operations for parsing multi-byte tags and lengths.